### PR TITLE
Feature(users): get own profile

### DIFF
--- a/api/utils/helpers/messages/success.py
+++ b/api/utils/helpers/messages/success.py
@@ -7,3 +7,4 @@ PASSWORD_RESET_LINK_SENT_MSG = 'Password reset link successfully sent.'\
     ' Please check your email to continue'
 PASSWORD_UPDATED_MSG = 'User password successfully updated'
 PROFILE_UPDATED_MSG = 'User profile successfully updated'
+PROFILE_FETCHED_MSG = 'User profile successfully fetched'

--- a/api/views/user.py
+++ b/api/views/user.py
@@ -19,7 +19,8 @@ from ..utils.helpers.messages.success import (USER_CREATED_MSG,
                                               USER_LOGGED_IN_MSG,
                                               PASSWORD_RESET_LINK_SENT_MSG,
                                               PASSWORD_UPDATED_MSG,
-                                              PROFILE_UPDATED_MSG)
+                                              PROFILE_UPDATED_MSG,
+                                              PROFILE_FETCHED_MSG)
 from ..utils.helpers.messages.error import (INVALID_USER_TOKEN_MSG,
                                             ALREADY_VERIFIED_MSG,
                                             INVALID_CREDENTIALS,
@@ -178,6 +179,19 @@ class UserResetPasswordResource(Resource):
 @user_namespace.route('/profile')
 class UserProfileResource(Resource):
     """" Resource class for user profile """
+
+    @token_required
+    @user_namespace.doc(responses=get_responses(200, 401))
+    def get(self):
+        """ Endpoint to get own profile """
+        user_id = request.decoded_token['user']['id']
+        user = User.find_by_id(user_id)
+        user_schema = UserSchema(exclude=['password'])
+        response = {
+            'user': user_schema.dump(user)
+        }
+
+        return Response.success(PROFILE_FETCHED_MSG, response, 200)
 
     @token_required
     @user_namespace.expect(profile_model)

--- a/tests/views/users/test_get_user_profile_endpoints.py
+++ b/tests/views/users/test_get_user_profile_endpoints.py
@@ -1,0 +1,21 @@
+""" Module for testing get user profile endpoints """
+
+import api.views.user
+from api.utils.helpers.messages.success import PROFILE_FETCHED_MSG
+from api.utils.helpers.messages.error import (KEY_REQUIRED_MSG)
+from ...constants import API_BASE_URL
+
+
+class TestGetUserProfile:
+    """ Class for testing get user profile resources """
+
+    def test_get_own_profile_succeeds(self, client, init_db, user_auth_header):
+        """ Testing Get own profile """
+
+        response = client.get(f'{API_BASE_URL}/users/profile',
+                              headers=user_auth_header)
+
+        assert response.status_code == 200
+        assert response.json['status'] == 'success'
+        assert response.json['message'] == PROFILE_FETCHED_MSG
+        assert 'user' in response.json['data']


### PR DESCRIPTION
**What does this PR do?**

Adds get user own profile functionality 

**Description of Task to be completed?**

An authenticated user can get their profile

**How should this be manually tested?**

- Checkout to the branch ft-get-own-profile
- Run the app with flask run
- Go to postman and send a `GET` request to `/users/profile` 
- The user profile should be fetched

**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

N/A

**Screenshots (if appropriate)**

N/A

**Questions:**

N/A
