### PR TITLE
Feature(categories): get single category

### DIFF
--- a/api/utils/helpers/messages/success.py
+++ b/api/utils/helpers/messages/success.py
@@ -13,3 +13,4 @@ PROFILE_FETCHED_MSG = 'User profile successfully fetched'
 # Categories
 CATEGORY_CREATED_MSG = 'Category successfully created'
 CATEGORIES_FETCHED_MSG = 'Categories successfully fetched'
+CATEGORY_FETCHED_MSG = 'Category successfully fetched'

--- a/api/views/category.py
+++ b/api/views/category.py
@@ -12,7 +12,9 @@ from ..utils.helpers.swagger.responses import get_responses
 from ..utils.helpers.swagger.models.category import (category_model)
 from ..utils.helpers.response import Response
 from ..utils.helpers.messages.success import (CATEGORY_CREATED_MSG,
-                                              CATEGORIES_FETCHED_MSG)
+                                              CATEGORIES_FETCHED_MSG,
+                                              CATEGORY_FETCHED_MSG)
+from ..utils.helpers.messages.error import (CATEGORY_NOT_FOUND_MSG)
 from ..utils.validators.category import CategoryValidators
 from ..models.category import Category
 from ..schemas.category import CategorySchema
@@ -53,3 +55,25 @@ class CategoryResource(Resource):
         }
 
         return Response.success(CATEGORIES_FETCHED_MSG, response, 200)
+
+
+@category_namespace.route('/<string:name>')
+class SingleCategoryResource(Resource):
+    """" Resource class for single category endpoints """
+
+    @category_namespace.doc(responses=get_responses(200, 404))
+    def get(self, name):
+        """ Endpoint to get single category """
+
+        category = Category.query.filter_by(name=name).first()
+
+        if not category:
+            return Response.error(
+                [get_error_body(name, CATEGORY_NOT_FOUND_MSG, 'name', 'url')], 404)
+
+        category_schema = CategorySchema()
+        response = {
+            'category': category_schema.dump(category)
+        }
+
+        return Response.success(CATEGORY_FETCHED_MSG, response, 200)

--- a/tests/views/categories/test_get_categories_endpoints.py
+++ b/tests/views/categories/test_get_categories_endpoints.py
@@ -1,7 +1,9 @@
 """ Module for testing get categories endpoints """
 
 import api.views.category
-from api.utils.helpers.messages.success import CATEGORIES_FETCHED_MSG
+from api.utils.helpers.messages.success import (CATEGORIES_FETCHED_MSG,
+                                                CATEGORY_FETCHED_MSG)
+from api.utils.helpers.messages.error import CATEGORY_NOT_FOUND_MSG
 from ...constants import API_BASE_URL
 
 
@@ -18,3 +20,23 @@ class TestGetCategoriesEndpoints:
         assert response.json['message'] == CATEGORIES_FETCHED_MSG
         assert 'categories' in response.json['data']
         assert len(response.json['data']['categories']) == 0
+
+    def test_get_single_category_succeeds(self, client, init_db, new_category):
+        """ Testing get single category """
+
+        new_category.save()
+        response = client.get(f'{API_BASE_URL}/categories/{new_category.name}')
+
+        assert response.status_code == 200
+        assert response.json['status'] == 'success'
+        assert response.json['message'] == CATEGORY_FETCHED_MSG
+        assert 'category' in response.json['data']
+
+    def test_get_single_category_with_unexisted_name_fails(self, client, init_db):
+        """ Testing get single category with unexisted name """
+
+        response = client.get(f'{API_BASE_URL}/categories/good')
+
+        assert response.status_code == 404
+        assert response.json['status'] == 'error'
+        assert response.json['errors'][0]['message'] == CATEGORY_NOT_FOUND_MSG


### PR DESCRIPTION
**What does this PR do?**

- Adds get single category functionality

**Description of Task to be completed?**

- Any user can fetch a single category by name

**How should this be manually tested?**

- Checkout to the branch `ft-get-single-category`
- Run the app with `flask run`
- Go to postman and send a GET request to `/categories/{name}` and replace `name` with the category name
- The named category should be fetched

**Any background context you want to provide?**

- N/A

**What are the relevant pivotal tracker stories?**

- N/A

**Screenshots (if appropriate)**

- N/A

**Questions:**

- N/A
