### PR TITLE
Feature(types): get one type by name

### DIFF
--- a/api/views/type.py
+++ b/api/views/type.py
@@ -12,7 +12,8 @@ from ..utils.helpers.swagger.responses import get_responses
 from ..utils.helpers.swagger.models.type import (type_model)
 from ..utils.helpers.response import Response
 from ..utils.helpers.messages.success import (TYPE_CREATED_MSG,
-                                              TYPES_FETCHED_MSG)
+                                              TYPES_FETCHED_MSG,
+                                              TYPE_FETCHED_MSG)
 from ..utils.helpers.messages.error import (TYPE_NOT_FOUND_MSG)
 from ..utils.validators.type import TypeValidators
 from ..models.type import Type
@@ -21,7 +22,7 @@ from ..schemas.type import TypeSchema
 
 @type_namespace.route('')
 class TypeResource(Resource):
-    """" Resource class for category endpoints """
+    """" Resource class for property types endpoints """
 
     @token_required
     @permission_required
@@ -54,3 +55,25 @@ class TypeResource(Resource):
         }
 
         return Response.success(TYPES_FETCHED_MSG, response, 200)
+
+
+@type_namespace.route('/<string:name>')
+class SingleTypeResource(Resource):
+    """" Resource class for single propty type endpoints """
+
+    @type_namespace.doc(responses=get_responses(200, 404))
+    def get(self, name):
+        """ Endpoint to get single type """
+
+        property_type = Type.query.filter_by(name=name).first()
+
+        if not property_type:
+            return Response.error(
+                [get_error_body(name, TYPE_NOT_FOUND_MSG, 'name', 'url')], 404)
+
+        type_schema = TypeSchema()
+        response = {
+            'type': type_schema.dump(property_type)
+        }
+
+        return Response.success(TYPE_FETCHED_MSG, response, 200)

--- a/tests/views/types/test_get_types_endpoints.py
+++ b/tests/views/types/test_get_types_endpoints.py
@@ -1,7 +1,8 @@
 """ Module for testing get types endpoints """
 
 import api.views.type
-from api.utils.helpers.messages.success import (TYPES_FETCHED_MSG)
+from api.utils.helpers.messages.success import (TYPES_FETCHED_MSG,
+                                                TYPE_FETCHED_MSG)
 from api.utils.helpers.messages.error import TYPE_NOT_FOUND_MSG
 from ...constants import API_BASE_URL
 
@@ -19,3 +20,23 @@ class TestGetTypesEndpoints:
         assert response.json['message'] == TYPES_FETCHED_MSG
         assert 'types' in response.json['data']
         assert len(response.json['data']['types']) == 0
+
+    def test_get_single_type_succeeds(self, client, init_db, new_type):
+        """ Testing get single type """
+
+        new_type.save()
+        response = client.get(f'{API_BASE_URL}/types/{new_type.name}')
+
+        assert response.status_code == 200
+        assert response.json['status'] == 'success'
+        assert response.json['message'] == TYPE_FETCHED_MSG
+        assert 'type' in response.json['data']
+
+    def test_get_single_type_with_unexisted_name_fails(self, client, init_db):
+        """ Testing get single type with unexisted name """
+
+        response = client.get(f'{API_BASE_URL}/types/good')
+
+        assert response.status_code == 404
+        assert response.json['status'] == 'error'
+        assert response.json['errors'][0]['message'] == TYPE_NOT_FOUND_MSG


### PR DESCRIPTION
**What does this PR do?**

- Adds get single type functionality

**Description of Task to be completed?**

-Any user can fetch a single type by name

**How should this be manually tested?**

- Checkout to the branch `ft-get-single-type`
- Run the app with `flask run`
- Go to postman and send a `GET` request to `/types/{name}` and replace `name` with the type name
- The named type should be fetched

**Any background context you want to provide?**

- N/A

**What are the relevant pivotal tracker stories?**

- N/A

**Screenshots (if appropriate)**

- N/A

**Questions:**

- N/A
