### PR TITLE
Update type

### DIFF
--- a/api/utils/validators/type.py
+++ b/api/utils/validators/type.py
@@ -34,3 +34,16 @@ class TypeValidators:
         if property_type:
             raise_conflict_error(
                 [get_error_body(name, TAKEN_TYPE_NAME_MSG, 'name')])
+
+    @classmethod
+    def validate_update(cls, data: dict, type_id):
+        """ Validates the type creation """
+
+        cls.validate_type_body(data)
+        name = data.get('name')
+        property_type = Type.query.filter(
+            Type.name == name.lower().strip()).first()
+
+        if property_type and property_type.id != type_id:
+            raise_conflict_error(
+                [get_error_body(name, TAKEN_TYPE_NAME_MSG, 'name')])

--- a/tests/fixtures/type.py
+++ b/tests/fixtures/type.py
@@ -9,3 +9,10 @@ def new_type(init_db):
     """ New type fixture """
 
     return Type(name='shared room')
+
+
+@pytest.fixture(scope='module')
+def another_type(init_db):
+    """ New type fixture """
+
+    return Type(name='test')

--- a/tests/mocks/type.py
+++ b/tests/mocks/type.py
@@ -9,3 +9,7 @@ INVALID_TYPE_WITH_EXISTED_NAME = {
     'name': 'shared room',
     'description': ''
 }
+
+INVALID_UPDATE_TYPE = {
+    'name': 'test'
+}

--- a/tests/views/types/test_update_and_delete_type_endpoints.py
+++ b/tests/views/types/test_update_and_delete_type_endpoints.py
@@ -1,0 +1,60 @@
+""" Module for testing update and delete type endpoints """
+
+from flask import json
+
+import api.views.type
+from api.utils.helpers.messages.success import (TYPE_UPDATED_MSG,
+                                                TYPE_DELETED_MSG)
+from api.utils.helpers.messages.error import (TYPE_NOT_FOUND_MSG,
+                                              TAKEN_TYPE_NAME_MSG)
+from ...mocks.type import (VALID_TYPE,
+                           INVALID_UPDATE_TYPE,)
+from ...constants import API_BASE_URL
+
+
+class TestUpdateType:
+    """ Class for testing update type endpoint """
+
+    def test_update_type_succeeds(self, client, init_db, new_type, admin_auth_header):
+        """ Testing update type """
+
+        new_type.save()
+        type_data = json.dumps(VALID_TYPE)
+        response = client.put(
+            f'{API_BASE_URL}/types/{new_type.name}',
+            data=type_data, headers=admin_auth_header)
+
+        assert response.status_code == 200
+        assert response.json['status'] == 'success'
+        assert response.json['message'] == TYPE_UPDATED_MSG
+        assert 'type' in response.json['data']
+        assert response.json['data']['type']['name'] == VALID_TYPE['name']
+
+    def test_update_type_with_unexisted_name_fails(self, client, init_db, admin_auth_header):
+        """ Testing update type with unexisted name """
+
+        type_data = json.dumps(VALID_TYPE)
+        response = client.put(
+            f'{API_BASE_URL}/types/good', data=type_data, headers=admin_auth_header)
+
+        assert response.status_code == 404
+        assert response.json['status'] == 'error'
+        assert response.json['errors'][0]['message'] == TYPE_NOT_FOUND_MSG
+
+    def test_update_type_with_existed_name_fails(self,
+                                                 client,
+                                                 new_type,
+                                                 another_type,
+                                                 admin_auth_header):
+        """ Testing update type with an existed type name """
+
+        new_type.save()
+        another_type.save()
+        type_data = json.dumps(INVALID_UPDATE_TYPE)
+        response = client.put(
+            f'{API_BASE_URL}/types/{new_type.name}',
+            data=type_data, headers=admin_auth_header)
+
+        assert response.status_code == 409
+        assert response.json['status'] == 'error'
+        assert response.json['errors'][0]['message'] == TAKEN_TYPE_NAME_MSG


### PR DESCRIPTION
**What does this PR do?**

- Update type

**Description of Task to be completed?**

- An authenticated admin user can update property type

**How should this be manually tested?**

- Checkout to the branch `ft-update-type`
- Run the app with `flask run`
- Go to postman and send a `PUT` request to `/types/{name}` with the required payload and replace `name` with the type name
- The named type should be updated

**Any background context you want to provide?**

- N/A

**What are the relevant pivotal tracker stories?**

- N/A

**Screenshots (if appropriate)**

- N/A

**Questions:**

- N/A
