### PR TITLE
Feature(types): delete type

### DIFF
--- a/api/views/category.py
+++ b/api/views/category.py
@@ -108,7 +108,7 @@ class SingleCategoryResource(Resource):
     @permission_required
     @category_namespace.doc(responses=get_responses(200, 401, 403, 404))
     def delete(self, name):
-        """ Endpoint to update category """
+        """ Endpoint to delete category """
 
         category = Category.query.filter_by(name=name).first()
 

--- a/api/views/type.py
+++ b/api/views/type.py
@@ -14,7 +14,8 @@ from ..utils.helpers.response import Response
 from ..utils.helpers.messages.success import (TYPE_CREATED_MSG,
                                               TYPES_FETCHED_MSG,
                                               TYPE_FETCHED_MSG,
-                                              TYPE_UPDATED_MSG)
+                                              TYPE_UPDATED_MSG,
+                                              TYPE_DELETED_MSG)
 from ..utils.helpers.messages.error import (TYPE_NOT_FOUND_MSG)
 from ..utils.validators.type import TypeValidators
 from ..models.type import Type
@@ -102,3 +103,23 @@ class SingleTypeResource(Resource):
         }
 
         return Response.success(TYPE_UPDATED_MSG, response, 200)
+
+    @token_required
+    @permission_required
+    @type_namespace.doc(responses=get_responses(200, 401, 403, 404))
+    def delete(self, name):
+        """ Endpoint to delete type """
+
+        property_type = Type.query.filter_by(name=name).first()
+
+        if not property_type:
+            return Response.error(
+                [get_error_body(name, TYPE_NOT_FOUND_MSG, 'name', 'url')], 404)
+
+        property_type.delete()
+        type_schema = TypeSchema()
+        response = {
+            'type': type_schema.dump(property_type)
+        }
+
+        return Response.success(TYPE_DELETED_MSG, response, 200)

--- a/tests/views/types/test_update_and_delete_type_endpoints.py
+++ b/tests/views/types/test_update_and_delete_type_endpoints.py
@@ -58,3 +58,28 @@ class TestUpdateType:
         assert response.status_code == 409
         assert response.json['status'] == 'error'
         assert response.json['errors'][0]['message'] == TAKEN_TYPE_NAME_MSG
+
+
+class TestDeleteType:
+    """ Class for testing delete type endpoint """
+
+    def test_delete_type_succeeds(self, client, init_db, new_type, admin_auth_header):
+        """ Testing delete type """
+
+        new_type.save()
+        response = client.delete(
+            f'{API_BASE_URL}/types/{new_type.name}', headers=admin_auth_header)
+
+        assert response.status_code == 200
+        assert response.json['status'] == 'success'
+        assert response.json['message'] == TYPE_DELETED_MSG
+
+    def test_delete_type_with_unexisted_name_fails(self, client, init_db, admin_auth_header):
+        """ Testing delete type with unexisted name """
+
+        response = client.delete(
+            f'{API_BASE_URL}/types/good', headers=admin_auth_header)
+
+        assert response.status_code == 404
+        assert response.json['status'] == 'error'
+        assert response.json['errors'][0]['message'] == TYPE_NOT_FOUND_MSG


### PR DESCRIPTION
**What does this PR do?**

- Delete type

**Description of Task to be completed?**

- An authenticated admin user can delete type

**How should this be manually tested?**

- Checkout to the branch `ft-delete-type`
- Run the app with `flask run`
- Go to postman and send a `DELETE` request to `/types/{name}` and replace `name` with the type name
- The named type should be deleted

**Any background context you want to provide?**

- N/A

**What are the relevant pivotal tracker stories?**

- N/A

**Screenshots (if appropriate)**

- N/A

**Questions:**

- N/A
