### PR TITLE
Feature(properties): fetch single property

### DIFF
--- a/api/views/property.py
+++ b/api/views/property.py
@@ -66,3 +66,26 @@ class PropertyResource(Resource):
         }
 
         return Response.success(PROPERTIES_FETCHED_MSG, response, 200)
+
+
+@property_namespace.route('/<int:property_id>')
+class SinglePropertyResource(Resource):
+    """" Resource class for single property endpoints """
+
+    @property_namespace.doc(responses=get_responses(200, 404))
+    def get(self, property_id):
+        """ Endpoint to get single property """
+
+        _property = Property.query.filter(
+            Property.id == property_id, Property.is_published).first()
+
+        if not _property:
+            return Response.error(
+                [get_error_body(property_id, PROPERTY_NOT_FOUND_MSG, 'property_id', 'url')], 404)
+
+        property_schema = PropertySchema()
+        response = {
+            'property': property_schema.dump(_property)
+        }
+
+        return Response.success(PROPERTY_FETCHED_MSG, response, 200)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,8 @@ from api.models.database import db
 pytest_plugins = ['tests.fixtures.user',
                   'tests.fixtures.authorization',
                   'tests.fixtures.category',
-                  'tests.fixtures.type']
+                  'tests.fixtures.type',
+                  'tests.fixtures.property']
 
 
 @pytest.fixture(scope='module')

--- a/tests/fixtures/property.py
+++ b/tests/fixtures/property.py
@@ -1,0 +1,26 @@
+""" Module for category fixtures """
+
+import pytest
+from api.models.property import Property
+
+
+@pytest.fixture(scope='module')
+def new_property(init_db, new_user, new_category, new_type):
+    """ New property fixture """
+    new_user.save()
+    new_category.save()
+    new_type.save()
+    return Property(owner_id=new_user.id,
+                    category_id=new_category.id,
+                    type_id=new_type.id,
+                    title='test property',
+                    address="test address",
+                    longitude=123.4456,
+                    latitude=-345.1233,
+                    guests=2,
+                    beds=2,
+                    baths=2,
+                    garages=1,
+                    price=10000,
+                    images=[],
+                    is_published=True)

--- a/tests/views/properties/test_get_properties_enpoints.py
+++ b/tests/views/properties/test_get_properties_enpoints.py
@@ -1,7 +1,8 @@
 """ Module for testing get properties endpoints """
 
 import api.views.property
-from api.utils.helpers.messages.success import (PROPERTIES_FETCHED_MSG)
+from api.utils.helpers.messages.success import (PROPERTIES_FETCHED_MSG,
+                                                PROPERTY_FETCHED_MSG)
 from api.utils.helpers.messages.error import PROPERTY_NOT_FOUND_MSG
 from ...constants import API_BASE_URL
 
@@ -19,3 +20,23 @@ class TestGetPropertiesEndpoints:
         assert response.json['message'] == PROPERTIES_FETCHED_MSG
         assert 'properties' in response.json['data']
         assert len(response.json['data']['properties']) == 0
+
+    def test_get_single_property_succeeds(self, client, init_db, new_property):
+        """ Testing get single property """
+
+        new_property.save()
+        response = client.get(f'{API_BASE_URL}/properties/{new_property.id}')
+
+        assert response.status_code == 200
+        assert response.json['status'] == 'success'
+        assert response.json['message'] == PROPERTY_FETCHED_MSG
+        assert 'property' in response.json['data']
+
+    def test_get_single_property_with_unexisted_id_fails(self, client, init_db):
+        """ Testing get single property with unexisted id """
+
+        response = client.get(f'{API_BASE_URL}/properties/100')
+
+        assert response.status_code == 404
+        assert response.json['status'] == 'error'
+        assert response.json['errors'][0]['message'] == PROPERTY_NOT_FOUND_MSG


### PR DESCRIPTION
**What does this PR do?**

- Fetch single property

**Description of Task to be completed?**

- Any user can fetch one property by id

**How should this be manually tested?**

- Checkout to the branch `ft-fetch-single-property`
- Run the app with `flask run`
- Go to `postman` and send a `GET` request to /properties/{property_id} and replace `property_id` with the property ID
- The property with the given ID should be fetched if it is available and is published

**Any background context you want to provide?**

- N/A

**What are the relevant pivotal tracker stories?**

- N/A

**Screenshots (if appropriate)**

- N/A

**Questions:**

- N/A
