### PR TITLE
Feature(properties): delete property

### DIFF
--- a/api/views/property.py
+++ b/api/views/property.py
@@ -111,3 +111,20 @@ class SinglePropertyResource(Resource):
         }
 
         return Response.success(PROPERTY_UPDATED_MSG, response, 200)
+
+    @token_required
+    @property_owner_permission_required
+    @property_namespace.doc(responses=get_responses(200, 401, 403, 404))
+    def delete(self, property_id):
+        """ Endpoint to delete property """
+
+        _property = Property.query.filter(
+            Property.id == property_id).first()
+        _property.delete()
+
+        property_schema = PropertySchema()
+        response = {
+            'property': property_schema.dump(_property)
+        }
+
+        return Response.success(PROPERTY_DELETED_MSG, response, 200)

--- a/tests/views/properties/test_update_and_delete_property_endpoints.py
+++ b/tests/views/properties/test_update_and_delete_property_endpoints.py
@@ -3,7 +3,8 @@
 from flask import json
 
 import api.views.property
-from api.utils.helpers.messages.success import (PROPERTY_UPDATED_MSG)
+from api.utils.helpers.messages.success import (PROPERTY_UPDATED_MSG,
+                                                PROPERTY_DELETED_MSG)
 from api.utils.helpers.messages.error import (PROPERTY_NOT_FOUND_MSG,
                                               UNAUTHORIZED_MSG)
 from ...mocks.property import (VALID_UPDATE_PROPERTY)
@@ -84,3 +85,18 @@ class TestUpdateProperty:
         assert response.status_code == 403
         assert response.json['status'] == 'error'
         assert response.json['errors'][0]['message'] == UNAUTHORIZED_MSG
+
+
+class TestDeleteProperty:
+    """ Class for testing delete property endpoint """
+
+    def test_delete_property_succeeds(self, client, init_db, new_property, user_auth_header):
+        """ Testing delete property """
+
+        new_property.save()
+        response = client.delete(
+            f'{API_BASE_URL}/properties/{new_property.id}', headers=user_auth_header)
+
+        assert response.status_code == 200
+        assert response.json['status'] == 'success'
+        assert response.json['message'] == PROPERTY_DELETED_MSG


### PR DESCRIPTION
**What does this PR do?**

- Delete property

**Description of Task to be completed?**

- An authenticated user can be able to delete his own property or an admin can delete any property

**How should this be manually tested?**

- Checkout to the branch `ft-delete-property`
- Run the app with `flask run`
- Go to `postman` and send a `DELETE` request to `/properties/{property_id}` and replace `property_id` with the property ID
- The property with the given ID should be deleted

**Any background context you want to provide?**

- N/A

**What are the relevant pivotal tracker stories?**

- N/A

**Screenshots (if appropriate)**

- N/A

**Questions:**

- N/A
