### PR TITLE
Feature(properties): unpublish property

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,11 @@ flask db upgrade
 ```
 flask run
 ```
+
+- Running tests and generating report
+
+```
+pytest
+```
+
+To further view the lines not tested or covered if there is any, an `htmlcov` directory will be created, get the `index.html` file by entering the directory and view it in your browser.

--- a/api/utils/helpers/messages/error.py
+++ b/api/utils/helpers/messages/error.py
@@ -39,6 +39,7 @@ TYPE_NOT_FOUND_MSG = 'Property type not found'
 PROPERTY_NOT_FOUND_MSG = 'Property not found'
 PROPERTY_NOT_AVAILABLE_MSG = 'Property not available for booking'
 PROPERTY_ALREADY_PUBLISHED_MSG = 'Property already published'
+PROPERTY_ALREADY_UNPUBLISHED_MSG = 'Property already unpublished'
 
 # Bookings
 CHECKIN_DATE_MSG = 'checkin_date must be a present or future date'

--- a/api/utils/helpers/messages/success.py
+++ b/api/utils/helpers/messages/success.py
@@ -31,6 +31,7 @@ PROPERTY_FETCHED_MSG = 'Property successfully fetched'
 PROPERTY_UPDATED_MSG = 'Property successfully updated'
 PROPERTY_DELETED_MSG = 'Property successfully deleted'
 PROPERTY_PUBLISHED_MSG = 'Property successfully published'
+PROPERTY_UNPUBLISHED_MSG = 'Property successfully unpublished'
 
 # Bookings
 BOOKING_CREATED_MSG = 'Property successfully booked'

--- a/api/views/property.py
+++ b/api/views/property.py
@@ -20,9 +20,11 @@ from ..utils.helpers.messages.success import (PROPERTY_CREATED_MSG,
                                               PROPERTY_UPDATED_MSG,
                                               PROPERTY_DELETED_MSG,
                                               PROPERTY_PUBLISHED_MSG,
+                                              PROPERTY_UNPUBLISHED_MSG,
                                               BOOKING_CREATED_MSG)
 from ..utils.helpers.messages.error import (PROPERTY_NOT_FOUND_MSG,
-                                            PROPERTY_ALREADY_PUBLISHED_MSG)
+                                            PROPERTY_ALREADY_PUBLISHED_MSG,
+                                            PROPERTY_ALREADY_UNPUBLISHED_MSG)
 from ..utils.helpers.constants import DATE_FORMAT
 from ..utils.validators.property import PropertyValidators
 from ..utils.validators.booking import BookingValidators
@@ -190,6 +192,33 @@ class PublishPropertyResource(Resource):
         }
 
         return Response.success(PROPERTY_PUBLISHED_MSG, response, 200)
+
+
+@property_namespace.route('/<int:property_id>/unpublish')
+class UnpublishPropertyResource(Resource):
+    """" Resource class for unpublishing a property endpoint """
+
+    @token_required
+    @property_owner_permission_required
+    @property_namespace.doc(responses=get_responses(200, 401, 403, 404))
+    def patch(self, property_id):
+        """ Endpoint to unpublish a property """
+
+        _property = Property.query.filter(
+            Property.id == property_id).first()
+
+        if not _property.is_published:
+            return Response.error(
+                [get_error_body(property_id,
+                                PROPERTY_ALREADY_UNPUBLISHED_MSG, 'property_id', 'url')], 400)
+
+        _property.update({'is_published': False})
+        property_schema = PropertySchema()
+        response = {
+            'property': property_schema.dump(_property)
+        }
+
+        return Response.success(PROPERTY_UNPUBLISHED_MSG, response, 200)
 
 
 @property_namespace.route('/<int:property_id>/book')

--- a/tests/views/properties/test_publish_property_endpoints.py
+++ b/tests/views/properties/test_publish_property_endpoints.py
@@ -3,8 +3,10 @@
 from flask import json
 
 import api.views.property
-from api.utils.helpers.messages.success import (PROPERTY_PUBLISHED_MSG)
-from api.utils.helpers.messages.error import (PROPERTY_ALREADY_PUBLISHED_MSG)
+from api.utils.helpers.messages.success import (PROPERTY_PUBLISHED_MSG,
+                                                PROPERTY_UNPUBLISHED_MSG)
+from api.utils.helpers.messages.error import (PROPERTY_ALREADY_PUBLISHED_MSG,
+                                              PROPERTY_ALREADY_UNPUBLISHED_MSG)
 from ...constants import API_BASE_URL
 
 
@@ -42,3 +44,39 @@ class TestPublishProperty:
         assert response.status_code == 400
         assert response.json['status'] == 'error'
         assert response.json['errors'][0]['message'] == PROPERTY_ALREADY_PUBLISHED_MSG
+
+
+class TestUnpublishProperty:
+    """ Class for testing unpublish property endpoint """
+
+    def test_unpublish_property_succeeds(self,
+                                         client,
+                                         init_db,
+                                         new_property,
+                                         user_auth_header):
+        """ Testing unpublish property """
+
+        new_property.save()
+        response = client.patch(
+            f'{API_BASE_URL}/properties/{new_property.id}/unpublish',
+            headers=user_auth_header)
+
+        assert response.status_code == 200
+        assert response.json['status'] == 'success'
+        assert response.json['message'] == PROPERTY_UNPUBLISHED_MSG
+
+    def test_publish_already_unpublished_property_fails(self,
+                                                        client,
+                                                        init_db,
+                                                        new_property,
+                                                        user_auth_header):
+        """ Testing unpublish an already unpublished property """
+
+        new_property.save()
+        response = client.patch(
+            f'{API_BASE_URL}/properties/{new_property.id}/unpublish',
+            headers=user_auth_header)
+
+        assert response.status_code == 400
+        assert response.json['status'] == 'error'
+        assert response.json['errors'][0]['message'] == PROPERTY_ALREADY_UNPUBLISHED_MSG


### PR DESCRIPTION
**What does this PR do?**

- Unpublish property

**Description of Task to be completed?**

- The owner of a property or an admin can unpublish the property

**How should this be manually tested?**

- Checkout to branch `ft-unpublish-property`
- Run the app with `flask run`
- Send a `PATCH` request to `/properties/{property_id}/unpublish` and replace `property_id` with the property ID
- The property with the given ID must be unpublished

**Any background context you want to provide?**

- N/A

**What are the relevant pivotal tracker stories?**

- N/A

**Screenshots (if appropriate)**

- N/A

**Questions:**

- N/A
